### PR TITLE
 ignore "," when searching numbers + support searching some elements by pinyin + a special searching mode to search voltage names and machine names separate

### DIFF
--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -19,7 +19,7 @@ public class NecharDisplayFilter extends PatternItemFilter {
     }
 
     private String deleteComma(String str) {
-        return str.replaceAll(",(?=[0,9])", "");
+        return str.replaceAll(",", "");
     }
 
     @Override

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -22,7 +22,7 @@ public class NecharDisplayFilter extends PatternItemFilter {
     public boolean matches(ItemStack itemStack) {
         String displayName = EnumChatFormatting.getTextWithoutFormattingCodes(itemStack.getDisplayName());
 
-        if (!displayName.isEmpty() && CONTEXT.contains(displayName, this.searchText)) {
+        if (!displayName.isEmpty() && CONTEXT.contains(displayName.replaceAll(",(?=[0,9])",""), this.searchText.replaceAll(",(?=[0,9])",""))) {
             return true;
         }
 
@@ -31,7 +31,7 @@ public class NecharDisplayFilter extends PatternItemFilter {
                 itemStack.getItem()
                     .getItemStackDisplayName(itemStack));
 
-            if (displayName.isEmpty() && CONTEXT.contains(displayName, this.searchText)) {
+            if (displayName.isEmpty() && CONTEXT.contains(displayName.replaceAll(",(?=[0,9])",""), this.searchText.replaceAll(",(?=[0,9])",""))) {
                 return true;
             }
         }

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -18,8 +18,8 @@ public class NecharDisplayFilter extends PatternItemFilter {
         this.searchText = searchText;
     }
     
-    private String deleteComma(String str){
-        return str.replaceAll(",(?=[0,9])","");
+    private String deleteComma(String str) {
+        return str.replaceAll(",(?=[0,9])", "");
     }
     
     @Override

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -38,4 +38,5 @@ public class NecharDisplayFilter extends PatternItemFilter {
 
         return super.matches(itemStack);
     }
+
 }

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -36,8 +36,7 @@ public class NecharDisplayFilter extends PatternItemFilter {
                 itemStack.getItem()
                     .getItemStackDisplayName(itemStack));
 
-            if (!displayName.isEmpty() 
-                && CONTEXT.contains(deleteComma(displayName), deleteComma(this.searchText))) {
+            if (!displayName.isEmpty() && CONTEXT.contains(deleteComma(displayName), deleteComma(this.searchText))) {
                 return true;
             }
         }

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -1,6 +1,7 @@
 package net.moecraft.nechar;
 
 import static net.sst03.nechar.NecharUtils.contain;
+import static net.vfyjxf.nechar.NechConfig.EnableVoltageSpecialSearchName;
 
 import java.util.regex.Pattern;
 
@@ -22,7 +23,7 @@ public class NecharDisplayFilter extends PatternItemFilter {
     public boolean matches(ItemStack itemStack) {
         String displayName = EnumChatFormatting.getTextWithoutFormattingCodes(itemStack.getDisplayName());
 
-        if (!displayName.isEmpty() && contain(displayName, this.searchText, true)) {
+        if (!displayName.isEmpty() && contain(displayName, this.searchText, EnableVoltageSpecialSearchName)) {
             return true;
         }
 
@@ -31,7 +32,7 @@ public class NecharDisplayFilter extends PatternItemFilter {
                 itemStack.getItem()
                     .getItemStackDisplayName(itemStack));
 
-            if (!displayName.isEmpty() && contain(displayName, this.searchText, true)) {
+            if (!displayName.isEmpty() && contain(displayName, this.searchText, EnableVoltageSpecialSearchName)) {
                 return true;
             }
         }

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -1,12 +1,9 @@
 package net.moecraft.nechar;
 
-import static net.moecraft.nechar.NotEnoughCharacters.CONTEXT;
-
+import static net.sst03.nechar.NecharUtils.contain;
 import java.util.regex.Pattern;
-
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
-
 import codechicken.nei.ItemList.PatternItemFilter;
 
 public class NecharDisplayFilter extends PatternItemFilter {
@@ -18,15 +15,11 @@ public class NecharDisplayFilter extends PatternItemFilter {
         this.searchText = searchText;
     }
 
-    private String deleteComma(String str) {
-        return str.replaceAll(",", "");
-    }
-
     @Override
     public boolean matches(ItemStack itemStack) {
         String displayName = EnumChatFormatting.getTextWithoutFormattingCodes(itemStack.getDisplayName());
 
-        if (!displayName.isEmpty() && CONTEXT.contains(deleteComma(displayName), deleteComma(this.searchText))) {
+        if (!displayName.isEmpty() && contain(displayName, this.searchText)) {
             return true;
         }
 
@@ -35,12 +28,12 @@ public class NecharDisplayFilter extends PatternItemFilter {
                 itemStack.getItem()
                     .getItemStackDisplayName(itemStack));
 
-            if (!displayName.isEmpty() && CONTEXT.contains(deleteComma(displayName), deleteComma(this.searchText))) {
+            if (!displayName.isEmpty() && contain(displayName, this.searchText)) {
                 return true;
             }
         }
 
         return super.matches(itemStack);
     }
-
+    
 }

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -38,5 +38,4 @@ public class NecharDisplayFilter extends PatternItemFilter {
 
         return super.matches(itemStack);
     }
-
 }

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -1,9 +1,12 @@
 package net.moecraft.nechar;
 
 import static net.sst03.nechar.NecharUtils.contain;
+
 import java.util.regex.Pattern;
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
+
 import codechicken.nei.ItemList.PatternItemFilter;
 
 public class NecharDisplayFilter extends PatternItemFilter {
@@ -35,5 +38,5 @@ public class NecharDisplayFilter extends PatternItemFilter {
 
         return super.matches(itemStack);
     }
-    
+
 }

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -1,7 +1,7 @@
 package net.moecraft.nechar;
 
-import static net.sst03.nechar.NecharUtils.contain;
-import static net.vfyjxf.nechar.NechConfig.EnableVoltageSpecialSearchName;
+import static net.moecraft.nechar.NecharUtils.contain;
+import static net.vfyjxf.nechar.NechConfig.enableVoltageSpecialSearchName;
 
 import java.util.regex.Pattern;
 
@@ -23,7 +23,7 @@ public class NecharDisplayFilter extends PatternItemFilter {
     public boolean matches(ItemStack itemStack) {
         String displayName = EnumChatFormatting.getTextWithoutFormattingCodes(itemStack.getDisplayName());
 
-        if (!displayName.isEmpty() && contain(displayName, this.searchText, EnableVoltageSpecialSearchName)) {
+        if (!displayName.isEmpty() && contain(displayName, this.searchText, enableVoltageSpecialSearchName)) {
             return true;
         }
 
@@ -32,7 +32,7 @@ public class NecharDisplayFilter extends PatternItemFilter {
                 itemStack.getItem()
                     .getItemStackDisplayName(itemStack));
 
-            if (!displayName.isEmpty() && contain(displayName, this.searchText, EnableVoltageSpecialSearchName)) {
+            if (!displayName.isEmpty() && contain(displayName, this.searchText, enableVoltageSpecialSearchName)) {
                 return true;
             }
         }

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -17,12 +17,14 @@ public class NecharDisplayFilter extends PatternItemFilter {
         super(pattern);
         this.searchText = searchText;
     }
-
+    private String deleteComma(String str){
+        return str.replaceAll(",(?=[0,9])","");
+    }
     @Override
     public boolean matches(ItemStack itemStack) {
         String displayName = EnumChatFormatting.getTextWithoutFormattingCodes(itemStack.getDisplayName());
 
-        if (!displayName.isEmpty() && CONTEXT.contains(displayName.replaceAll(",(?=[0,9])",""), this.searchText.replaceAll(",(?=[0,9])",""))) {
+        if (!displayName.isEmpty() && CONTEXT.contains(deleteComma(displayName), deleteComma(this.searchText))) {
             return true;
         }
 
@@ -31,7 +33,7 @@ public class NecharDisplayFilter extends PatternItemFilter {
                 itemStack.getItem()
                     .getItemStackDisplayName(itemStack));
 
-            if (displayName.isEmpty() && CONTEXT.contains(displayName.replaceAll(",(?=[0,9])",""), this.searchText.replaceAll(",(?=[0,9])",""))) {
+            if (displayName.isEmpty() && CONTEXT.contains(deleteComma(displayName), deleteComma(this.searchText))) {
                 return true;
             }
         }

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -17,9 +17,11 @@ public class NecharDisplayFilter extends PatternItemFilter {
         super(pattern);
         this.searchText = searchText;
     }
+    
     private String deleteComma(String str){
         return str.replaceAll(",(?=[0,9])","");
     }
+    
     @Override
     public boolean matches(ItemStack itemStack) {
         String displayName = EnumChatFormatting.getTextWithoutFormattingCodes(itemStack.getDisplayName());

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -17,16 +17,17 @@ public class NecharDisplayFilter extends PatternItemFilter {
         super(pattern);
         this.searchText = searchText;
     }
-    
+
     private String deleteComma(String str) {
         return str.replaceAll(",(?=[0,9])", "");
     }
-    
+
     @Override
     public boolean matches(ItemStack itemStack) {
         String displayName = EnumChatFormatting.getTextWithoutFormattingCodes(itemStack.getDisplayName());
 
-        if (!displayName.isEmpty() && CONTEXT.contains(deleteComma(displayName), deleteComma(this.searchText))) {
+        if (!displayName.isEmpty() 
+            && CONTEXT.contains(deleteComma(displayName), deleteComma(this.searchText))) {
             return true;
         }
 
@@ -35,7 +36,8 @@ public class NecharDisplayFilter extends PatternItemFilter {
                 itemStack.getItem()
                     .getItemStackDisplayName(itemStack));
 
-            if (displayName.isEmpty() && CONTEXT.contains(deleteComma(displayName), deleteComma(this.searchText))) {
+            if (!displayName.isEmpty() 
+                && CONTEXT.contains(deleteComma(displayName), deleteComma(this.searchText))) {
                 return true;
             }
         }

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -22,7 +22,7 @@ public class NecharDisplayFilter extends PatternItemFilter {
     public boolean matches(ItemStack itemStack) {
         String displayName = EnumChatFormatting.getTextWithoutFormattingCodes(itemStack.getDisplayName());
 
-        if (!displayName.isEmpty() && contain(displayName, this.searchText)) {
+        if (!displayName.isEmpty() && contain(displayName, this.searchText, true)) {
             return true;
         }
 
@@ -31,7 +31,7 @@ public class NecharDisplayFilter extends PatternItemFilter {
                 itemStack.getItem()
                     .getItemStackDisplayName(itemStack));
 
-            if (!displayName.isEmpty() && contain(displayName, this.searchText)) {
+            if (!displayName.isEmpty() && contain(displayName, this.searchText, true)) {
                 return true;
             }
         }

--- a/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharDisplayFilter.java
@@ -26,8 +26,7 @@ public class NecharDisplayFilter extends PatternItemFilter {
     public boolean matches(ItemStack itemStack) {
         String displayName = EnumChatFormatting.getTextWithoutFormattingCodes(itemStack.getDisplayName());
 
-        if (!displayName.isEmpty() 
-            && CONTEXT.contains(deleteComma(displayName), deleteComma(this.searchText))) {
+        if (!displayName.isEmpty() && CONTEXT.contains(deleteComma(displayName), deleteComma(this.searchText))) {
             return true;
         }
 

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -19,7 +19,7 @@ public class NecharTooltipFilter extends TooltipFilter {
 
     @Override
     public boolean matches(ItemStack itemStack) {
-        return contain(getSearchTooltip(itemStack), this.searchText) || super.matches(itemStack);
+        return contain(getSearchTooltip(itemStack), this.searchText, false) || super.matches(itemStack);
     }
 
 }

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -16,14 +16,15 @@ public class NecharTooltipFilter extends TooltipFilter {
         super(pattern);
         this.searchText = searchText;
     }
-    
+
     private String deleteComma(String str) {
         return str.replaceAll(",(?=[0,9])", "");
     }
-    
+
     @Override
     public boolean matches(ItemStack itemStack) {
-        return CONTEXT.contains(deleteComma(getSearchTooltip(itemStack)), deleteComma(this.searchText)) 
+        return CONTEXT.contains(
+            deleteComma(getSearchTooltip(itemStack)), deleteComma(this.searchText))
             || super.matches(itemStack);
     }
 

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -1,7 +1,7 @@
 package net.moecraft.nechar;
 
-import static net.sst03.nechar.NecharUtils.contain;
-import static net.vfyjxf.nechar.NechConfig.EnableVoltageSpecialSearchTooltips;
+import static net.moecraft.nechar.NecharUtils.contain;
+import static net.vfyjxf.nechar.NechConfig.enableVoltageSpecialSearchTooltips;
 
 import java.util.regex.Pattern;
 
@@ -20,7 +20,7 @@ public class NecharTooltipFilter extends TooltipFilter {
 
     @Override
     public boolean matches(ItemStack itemStack) {
-        return contain(getSearchTooltip(itemStack), this.searchText, EnableVoltageSpecialSearchTooltips)
+        return contain(getSearchTooltip(itemStack), this.searchText, enableVoltageSpecialSearchTooltips)
             || super.matches(itemStack);
     }
 

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -1,11 +1,8 @@
 package net.moecraft.nechar;
 
-import static net.moecraft.nechar.NotEnoughCharacters.CONTEXT;
-
+import static net.sst03.nechar.NecharUtils.contain;
 import java.util.regex.Pattern;
-
 import net.minecraft.item.ItemStack;
-
 import codechicken.nei.search.TooltipFilter;
 
 public class NecharTooltipFilter extends TooltipFilter {
@@ -17,17 +14,9 @@ public class NecharTooltipFilter extends TooltipFilter {
         this.searchText = searchText;
     }
 
-    private String deleteComma(String str) {
-        return str.replaceAll("(?<=[0-9]),(?=[0-9])", "");
-    }
-
     @Override
     public boolean matches(ItemStack itemStack) {
-        String tooltip = getSearchTooltip(itemStack);
-        if (this.searchText.contains(",")) {
-            return CONTEXT.contains(tooltip, this.searchText) || super.matches(itemStack);
-        }
-        return CONTEXT.contains(deleteComma(tooltip), deleteComma(this.searchText))
+        return contain(getSearchTooltip(itemStack), this.searchText)
             || super.matches(itemStack);
     }
 

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -19,7 +19,7 @@ public class NecharTooltipFilter extends TooltipFilter {
 
     @Override
     public boolean matches(ItemStack itemStack) {
-        return CONTEXT.contains(getSearchTooltip(itemStack), this.searchText) || super.matches(itemStack);
+        return CONTEXT.contains(getSearchTooltip(itemStack).replaceAll(",(?=[0,9])",""), this.searchText.replaceAll(",(?=[0,9])","")) || super.matches(itemStack);
     }
 
 }

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -21,7 +21,8 @@ public class NecharTooltipFilter extends TooltipFilter {
     }
     @Override
     public boolean matches(ItemStack itemStack) {
-        return CONTEXT.contains(deleteComma(getSearchTooltip(itemStack)), deleteComma(this.searchText)) || super.matches(itemStack);
+        return CONTEXT.contains(deleteComma(getSearchTooltip(itemStack)), deleteComma(this.searchText)) 
+            || super.matches(itemStack);
     }
 
 }

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -16,10 +16,12 @@ public class NecharTooltipFilter extends TooltipFilter {
         super(pattern);
         this.searchText = searchText;
     }
-
+    private String deleteComma(String str){
+        return str.replaceAll(",(?=[0,9])","");
+    }
     @Override
     public boolean matches(ItemStack itemStack) {
-        return CONTEXT.contains(getSearchTooltip(itemStack).replaceAll(",(?=[0,9])",""), this.searchText.replaceAll(",(?=[0,9])","")) || super.matches(itemStack);
+        return CONTEXT.contains(deleteComma(getSearchTooltip(itemStack)), deleteComma(this.searchText) || super.matches(itemStack);
     }
 
 }

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -18,12 +18,16 @@ public class NecharTooltipFilter extends TooltipFilter {
     }
 
     private String deleteComma(String str) {
-        return str.replaceAll(",(?=[0,9])", "");
+        return str.replaceAll("(?<=[0-9]),(?=[0-9])", "");
     }
 
     @Override
     public boolean matches(ItemStack itemStack) {
-        return CONTEXT.contains(deleteComma(getSearchTooltip(itemStack)), deleteComma(this.searchText))
+        String tooltip = getSearchTooltip(itemStack);
+        if (this.searchText.contains(",")) {
+            return CONTEXT.contains(tooltip, this.searchText) || super.matches(itemStack);
+        }
+        return CONTEXT.contains(deleteComma(tooltip), deleteComma(this.searchText))
             || super.matches(itemStack);
     }
 

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -1,8 +1,11 @@
 package net.moecraft.nechar;
 
 import static net.sst03.nechar.NecharUtils.contain;
+
 import java.util.regex.Pattern;
+
 import net.minecraft.item.ItemStack;
+
 import codechicken.nei.search.TooltipFilter;
 
 public class NecharTooltipFilter extends TooltipFilter {
@@ -16,8 +19,7 @@ public class NecharTooltipFilter extends TooltipFilter {
 
     @Override
     public boolean matches(ItemStack itemStack) {
-        return contain(getSearchTooltip(itemStack), this.searchText)
-            || super.matches(itemStack);
+        return contain(getSearchTooltip(itemStack), this.searchText) || super.matches(itemStack);
     }
 
 }

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -16,9 +16,11 @@ public class NecharTooltipFilter extends TooltipFilter {
         super(pattern);
         this.searchText = searchText;
     }
-    private String deleteComma(String str){
-        return str.replaceAll(",(?=[0,9])","");
+    
+    private String deleteComma(String str) {
+        return str.replaceAll(",(?=[0,9])", "");
     }
+    
     @Override
     public boolean matches(ItemStack itemStack) {
         return CONTEXT.contains(deleteComma(getSearchTooltip(itemStack)), deleteComma(this.searchText)) 

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -21,7 +21,7 @@ public class NecharTooltipFilter extends TooltipFilter {
     }
     @Override
     public boolean matches(ItemStack itemStack) {
-        return CONTEXT.contains(deleteComma(getSearchTooltip(itemStack)), deleteComma(this.searchText) || super.matches(itemStack);
+        return CONTEXT.contains(deleteComma(getSearchTooltip(itemStack)), deleteComma(this.searchText)) || super.matches(itemStack);
     }
 
 }

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -1,6 +1,7 @@
 package net.moecraft.nechar;
 
 import static net.sst03.nechar.NecharUtils.contain;
+import static net.vfyjxf.nechar.NechConfig.EnableVoltageSpecialSearchTooltips;
 
 import java.util.regex.Pattern;
 
@@ -19,7 +20,8 @@ public class NecharTooltipFilter extends TooltipFilter {
 
     @Override
     public boolean matches(ItemStack itemStack) {
-        return contain(getSearchTooltip(itemStack), this.searchText, false) || super.matches(itemStack);
+        return contain(getSearchTooltip(itemStack), this.searchText, EnableVoltageSpecialSearchTooltips)
+            || super.matches(itemStack);
     }
 
 }

--- a/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
+++ b/src/main/java/net/moecraft/nechar/NecharTooltipFilter.java
@@ -23,8 +23,7 @@ public class NecharTooltipFilter extends TooltipFilter {
 
     @Override
     public boolean matches(ItemStack itemStack) {
-        return CONTEXT.contains(
-            deleteComma(getSearchTooltip(itemStack)), deleteComma(this.searchText))
+        return CONTEXT.contains(deleteComma(getSearchTooltip(itemStack)), deleteComma(this.searchText))
             || super.matches(itemStack);
     }
 

--- a/src/main/java/net/moecraft/nechar/NecharUtils.java
+++ b/src/main/java/net/moecraft/nechar/NecharUtils.java
@@ -1,7 +1,7 @@
-package net.sst03.nechar;
+package net.moecraft.nechar;
 
 import static net.moecraft.nechar.NotEnoughCharacters.CONTEXT;
-import static net.vfyjxf.nechar.NechConfig.EnableIgnoreComma;
+import static net.vfyjxf.nechar.NechConfig.enableIgnoreComma;
 
 public class NecharUtils {
 
@@ -51,7 +51,7 @@ public class NecharUtils {
         sourseText = replaceExtraChars(sourseText);
         searchText = replaceExtraChars(searchText);
 
-        if (EnableIgnoreComma && !searchText.contains(",")) {
+        if (enableIgnoreComma && !searchText.contains(",")) {
             sourseText = deleteComma(sourseText);
             searchText = deleteComma(searchText);
         }

--- a/src/main/java/net/moecraft/nechar/NotEnoughCharacters.java
+++ b/src/main/java/net/moecraft/nechar/NotEnoughCharacters.java
@@ -36,46 +36,32 @@ public class NotEnoughCharacters {
             super.load(feed);
             // 钅卢
             feed.accept('\ue900', new String[] { "lu2", "jinlu" });
-            feed.accept('\udf3b', new String[] { "lu2", "jinlu" });
             // 钅杜
             feed.accept('\ue901', new String[] { "du4", "jindu" });
-            feed.accept('\udf4a', new String[] { "du4", "jindu" });
             // 钅喜
             feed.accept('\ue902', new String[] { "xi3", "jinxi" });
-            feed.accept('\udf73', new String[] { "xi3", "jinxi" });
             // 钅波
             feed.accept('\ue903', new String[] { "bo1", "jinbo" });
-            feed.accept('\udf5b', new String[] { "bo1", "jinbo" });
             // 钅黑
             feed.accept('\ue904', new String[] { "hei1", "jinhei" });
-            feed.accept('\udf76', new String[] { "hei1", "jinhei" });
             // 钅麦
             feed.accept('\u9fcf', new String[] { "mai4", "jinmai" });
-            // feed.accept('\u9fcf', new String[] { "mai4", "jinmai" });
             // 钅达
             feed.accept('\ue906', new String[] { "da2", "jinda" });
-            feed.accept('\udffc', new String[] { "da2", "jinda" });
             // 钅仑
             feed.accept('\ue907', new String[] { "lun2", "jinlun" });
-            feed.accept('\udf2d', new String[] { "lun2", "jinlun" });
             // 钅哥
             feed.accept('\u9fd4', new String[] { "ge1", "jinge" });
-            // feed.accept('\u9fd4', new String[] { "ge1", "jinge" });
             // 钅尔
             feed.accept('\u9fed', new String[] { "ni3", "jiner" });
-            // feed.accept('\u9fed', new String[] { "ni3", "jiner" });
             // 钅夫
             feed.accept('\ue90a', new String[] { "fu1", "jinfu" });
-            feed.accept('\udce7', new String[] { "fu1", "jinfu" });
             // 钅立
             feed.accept('\ue90c', new String[] { "li4", "jinli" });
-            feed.accept('\udff7', new String[] { "li4", "jinli" });
             // 石田
             feed.accept('\u9fec', new String[] { "tian2", "shitian" });
-            // feed.accept('\u9fec', new String[] { "tian2", "shitian" });
             // 气奥
             feed.accept('\u9feb', new String[] { "ao4", "qiao", "aoqi" });
-            // feed.accept('\u9feb', new String[] { "ao4", "qiao", "aoqi" });
         }
     }
 

--- a/src/main/java/net/moecraft/nechar/NotEnoughCharacters.java
+++ b/src/main/java/net/moecraft/nechar/NotEnoughCharacters.java
@@ -34,20 +34,47 @@ public class NotEnoughCharacters {
         @Override
         public void load(BiConsumer<Character, String[]> feed) {
             super.load(feed);
-            feed.accept('\ue900', new String[] { "lu2", "jinlu" }); // 钅卢
-            feed.accept('\ue901', new String[] { "du4", "jindu" }); // 钅杜
-            feed.accept('\ue902', new String[] { "xi3", "jinxi" }); // 钅喜
-            feed.accept('\ue903', new String[] { "bo1", "jinbo" }); // 钅波
-            feed.accept('\ue904', new String[] { "hei1", "jinhei" }); // 钅黑
-            feed.accept('\u9fcf', new String[] { "mai4", "jinmai" });// 钅麦
-            feed.accept('\ue906', new String[] { "da2", "jinda" });// 钅达
-            feed.accept('\ue907', new String[] { "lun2", "jinlun" });// 钅仑
-            feed.accept('\u9fd4', new String[] { "ge1", "jinge" });// 钅哥
-            feed.accept('\u9fed', new String[] { "ni3", "jiner" });// 钅尔
-            feed.accept('\ue90a', new String[] { "fu1", "jinfu" });// 钅夫
-            feed.accept('\ue90c', new String[] { "li4", "jinli" });// 钅立
-            feed.accept('\u9fec', new String[] { "tian2", "shitian" });// 石田
-            feed.accept('\u9feb', new String[] { "ao4", "qiao", "aoqi" });// 气奥
+            feed.accept('\ue900', new String[] { "lu2", "jinlu" });
+            feed.accept('\udf3b', new String[] { "lu2", "jinlu" }); // 钅卢
+
+            feed.accept('\ue901', new String[] { "du4", "jindu" });
+            feed.accept('\udf4a', new String[] { "du4", "jindu" }); // 钅杜
+
+            feed.accept('\ue902', new String[] { "xi3", "jinxi" });
+            feed.accept('\udf73', new String[] { "xi3", "jinxi" }); // 钅喜
+
+            feed.accept('\ue903', new String[] { "bo1", "jinbo" });
+            feed.accept('\udf5b', new String[] { "bo1", "jinbo" }); // 钅波
+
+            feed.accept('\ue904', new String[] { "hei1", "jinhei" });
+            feed.accept('\udf76', new String[] { "hei1", "jinhei" }); // 钅黑
+
+            feed.accept('\u9fcf', new String[] { "mai4", "jinmai" });
+            //feed.accept('\u9fcf', new String[] { "mai4", "jinmai" }); // 钅麦
+
+            feed.accept('\ue906', new String[] { "da2", "jinda" });
+            feed.accept('\udffc', new String[] { "da2", "jinda" }); // 钅达
+
+            feed.accept('\ue907', new String[] { "lun2", "jinlun" });
+            feed.accept('\udf2d', new String[] { "lun2", "jinlun" }); // 钅仑
+            
+            feed.accept('\u9fd4', new String[] { "ge1", "jinge" });
+            //feed.accept('\u9fd4', new String[] { "ge1", "jinge" }); // 钅哥
+
+            feed.accept('\u9fed', new String[] { "ni3", "jiner" });
+            //feed.accept('\u9fed', new String[] { "ni3", "jiner" }); // 钅尔
+
+            feed.accept('\ue90a', new String[] { "fu1", "jinfu" });
+            feed.accept('\udce7', new String[] { "fu1", "jinfu" }); // 钅夫
+
+            feed.accept('\ue90c', new String[] { "li4", "jinli" });
+            feed.accept('\udff7', new String[] { "li4", "jinli" }); // 钅立
+
+            feed.accept('\u9fec', new String[] { "tian2", "shitian" });
+            //feed.accept('\u9fec', new String[] { "tian2", "shitian" }); // 石田
+
+            feed.accept('\u9feb', new String[] { "ao4", "qiao", "aoqi" });
+            //feed.accept('\u9feb', new String[] { "ao4", "qiao", "aoqi" }); // 气奥
         }
     }
 

--- a/src/main/java/net/moecraft/nechar/NotEnoughCharacters.java
+++ b/src/main/java/net/moecraft/nechar/NotEnoughCharacters.java
@@ -51,19 +51,19 @@ public class NotEnoughCharacters {
             feed.accept('\udf76', new String[] { "hei1", "jinhei" });
             // 钅麦
             feed.accept('\u9fcf', new String[] { "mai4", "jinmai" });
-            //feed.accept('\u9fcf', new String[] { "mai4", "jinmai" });
+            // feed.accept('\u9fcf', new String[] { "mai4", "jinmai" });
             // 钅达
             feed.accept('\ue906', new String[] { "da2", "jinda" });
             feed.accept('\udffc', new String[] { "da2", "jinda" });
             // 钅仑
             feed.accept('\ue907', new String[] { "lun2", "jinlun" });
             feed.accept('\udf2d', new String[] { "lun2", "jinlun" });
-            // // 钅哥
+            // 钅哥
             feed.accept('\u9fd4', new String[] { "ge1", "jinge" });
-            //feed.accept('\u9fd4', new String[] { "ge1", "jinge" });
+            // feed.accept('\u9fd4', new String[] { "ge1", "jinge" });
             // 钅尔
             feed.accept('\u9fed', new String[] { "ni3", "jiner" });
-            //feed.accept('\u9fed', new String[] { "ni3", "jiner" });
+            // feed.accept('\u9fed', new String[] { "ni3", "jiner" });
             // 钅夫
             feed.accept('\ue90a', new String[] { "fu1", "jinfu" });
             feed.accept('\udce7', new String[] { "fu1", "jinfu" });
@@ -72,10 +72,10 @@ public class NotEnoughCharacters {
             feed.accept('\udff7', new String[] { "li4", "jinli" });
             // 石田
             feed.accept('\u9fec', new String[] { "tian2", "shitian" });
-            //feed.accept('\u9fec', new String[] { "tian2", "shitian" });
+            // feed.accept('\u9fec', new String[] { "tian2", "shitian" });
             // 气奥
             feed.accept('\u9feb', new String[] { "ao4", "qiao", "aoqi" });
-            //feed.accept('\u9feb', new String[] { "ao4", "qiao", "aoqi" });
+            // feed.accept('\u9feb', new String[] { "ao4", "qiao", "aoqi" });
         }
     }
 

--- a/src/main/java/net/moecraft/nechar/NotEnoughCharacters.java
+++ b/src/main/java/net/moecraft/nechar/NotEnoughCharacters.java
@@ -34,47 +34,48 @@ public class NotEnoughCharacters {
         @Override
         public void load(BiConsumer<Character, String[]> feed) {
             super.load(feed);
+            // 钅卢
             feed.accept('\ue900', new String[] { "lu2", "jinlu" });
-            feed.accept('\udf3b', new String[] { "lu2", "jinlu" }); // 钅卢
-
+            feed.accept('\udf3b', new String[] { "lu2", "jinlu" });
+            // 钅杜
             feed.accept('\ue901', new String[] { "du4", "jindu" });
-            feed.accept('\udf4a', new String[] { "du4", "jindu" }); // 钅杜
-
+            feed.accept('\udf4a', new String[] { "du4", "jindu" });
+            // 钅喜
             feed.accept('\ue902', new String[] { "xi3", "jinxi" });
-            feed.accept('\udf73', new String[] { "xi3", "jinxi" }); // 钅喜
-
+            feed.accept('\udf73', new String[] { "xi3", "jinxi" });
+            // 钅波
             feed.accept('\ue903', new String[] { "bo1", "jinbo" });
-            feed.accept('\udf5b', new String[] { "bo1", "jinbo" }); // 钅波
-
+            feed.accept('\udf5b', new String[] { "bo1", "jinbo" });
+            // 钅黑
             feed.accept('\ue904', new String[] { "hei1", "jinhei" });
-            feed.accept('\udf76', new String[] { "hei1", "jinhei" }); // 钅黑
-
+            feed.accept('\udf76', new String[] { "hei1", "jinhei" });
+            // 钅麦
             feed.accept('\u9fcf', new String[] { "mai4", "jinmai" });
-            //feed.accept('\u9fcf', new String[] { "mai4", "jinmai" }); // 钅麦
-
+            //feed.accept('\u9fcf', new String[] { "mai4", "jinmai" });
+            // 钅达
             feed.accept('\ue906', new String[] { "da2", "jinda" });
-            feed.accept('\udffc', new String[] { "da2", "jinda" }); // 钅达
-
+            feed.accept('\udffc', new String[] { "da2", "jinda" });
+            // 钅仑
             feed.accept('\ue907', new String[] { "lun2", "jinlun" });
-            feed.accept('\udf2d', new String[] { "lun2", "jinlun" }); // 钅仑
-            
+            feed.accept('\udf2d', new String[] { "lun2", "jinlun" });
+            // // 钅哥
             feed.accept('\u9fd4', new String[] { "ge1", "jinge" });
-            //feed.accept('\u9fd4', new String[] { "ge1", "jinge" }); // 钅哥
-
+            //feed.accept('\u9fd4', new String[] { "ge1", "jinge" });
+            // 钅尔
             feed.accept('\u9fed', new String[] { "ni3", "jiner" });
-            //feed.accept('\u9fed', new String[] { "ni3", "jiner" }); // 钅尔
-
+            //feed.accept('\u9fed', new String[] { "ni3", "jiner" });
+            // 钅夫
             feed.accept('\ue90a', new String[] { "fu1", "jinfu" });
-            feed.accept('\udce7', new String[] { "fu1", "jinfu" }); // 钅夫
-
+            feed.accept('\udce7', new String[] { "fu1", "jinfu" });
+            // 钅立
             feed.accept('\ue90c', new String[] { "li4", "jinli" });
-            feed.accept('\udff7', new String[] { "li4", "jinli" }); // 钅立
-
+            feed.accept('\udff7', new String[] { "li4", "jinli" });
+            // 石田
             feed.accept('\u9fec', new String[] { "tian2", "shitian" });
-            //feed.accept('\u9fec', new String[] { "tian2", "shitian" }); // 石田
-
+            //feed.accept('\u9fec', new String[] { "tian2", "shitian" });
+            // 气奥
             feed.accept('\u9feb', new String[] { "ao4", "qiao", "aoqi" });
-            //feed.accept('\u9feb', new String[] { "ao4", "qiao", "aoqi" }); // 气奥
+            //feed.accept('\u9feb', new String[] { "ao4", "qiao", "aoqi" });
         }
     }
 

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -30,14 +30,31 @@ public class NecharUtils {
         return str;
     }
 
-    public static boolean contain(String sourseText, String searchText) {
+    private static boolean containWithVoltage(String voltage, String sourseText, String searchText) {
+        if (!searchText.contains(voltage)) {
+            return false;
+        }
+        if (!sourseText.contains(voltage)) {
+            return false;
+        } // check if [voltage] can be found
+        String[] sList = searchText.split(voltage, 2); // check if texts between "max" can be found
+        if (sList.length == 2 && !CONTEXT.contains(sourseText, sList[1])) {
+            return false;
+        }
+        return CONTEXT.contains(sourseText, sList[0]);
+    }
 
-        searchText = replaceExtraChars(searchText);
+    private static String[] voltageListWithLetterV = { "ulv", "lv", "mv", "hv", "ev", "iv", "luv", "uv", "uhv", "uev",
+        "uiv", "umv", "uxv" };
+
+    public static boolean contain(String sourseText, String searchText, Boolean enableSpecialSearch) {
+
         sourseText = replaceExtraChars(sourseText);
+        searchText = replaceExtraChars(searchText);
 
         if (EnableIgnoreComma && !searchText.contains(",")) {
-            searchText = deleteComma(searchText);
             sourseText = deleteComma(sourseText);
+            searchText = deleteComma(searchText);
         }
 
         if (CONTEXT.contains(sourseText, searchText)) {
@@ -49,153 +66,21 @@ public class NecharUtils {
             return false;
         }
 
+        sourseText = sourseText.toLowerCase();
         searchText = searchText.toLowerCase();
 
-        if (searchText.contains("max")) {
-            sourseText = sourseText.toLowerCase();
-
-            if (!sourseText.contains("max")) { // check if "max" can be found
-                return false;
-            }
-
-            String[] sList = searchText.split("max"); // check if texts between "max" can be found
-
-            if (sList.length == 2 && !CONTEXT.contains(sourseText, sList[1])) {
-                return false;
-            }
-
-            return CONTEXT.contains(sourseText, sList[0]);
-
-        } else if (searchText.contains("zpm")) {
-            sourseText = sourseText.toLowerCase();
-
-            if (!sourseText.contains("zpm")) { // check if "zpm" can be found
-                return false;
-            }
-
-            String[] sList = searchText.split("zpm"); // check if texts between "zpm" can be found
-
-            if (sList.length == 2 && !CONTEXT.contains(sourseText, sList[1])) {
-                return false;
-            }
-
-            return CONTEXT.contains(sourseText, sList[0]);
-
-        } else if (searchText.contains("v")) {
-            sourseText = sourseText.toLowerCase();
-
-            if (!sourseText.contains("v")) {
-                return false;
-            }
-
-            int i = 1;// voltage name is like "??v", not "v?"
-            final int l = searchText.length();
-
-            // try to find a voltage name
-            while (i < l) {
-                int j = searchText.indexOf('v', i);
-
-                if (j == -1) { // cannot find any voltage name
-                    return false;
-                }
-
-                i = j + 1;
-                switch (searchText.charAt(j - 1)) { // ulv/umv/uhv/uiv/uev are basicly same
-                    case 'l':
-
-                        if (!(sourseText.contains("lv") || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
-                            return false;
-                        }
-
-                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("ulv")
-                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2))) {
-                            return true;
-                        }
-
-                        return CONTEXT.contains(sourseText, searchText.substring(0, j - 1));
-
-                    case 'm':
-
-                        if (!(sourseText.contains("mv") || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
-                            return false;
-                        }
-
-                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("umv")
-                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2))) {
-                            return true;
-                        }
-
-                        return CONTEXT.contains(sourseText, searchText.substring(0, j - 1));
-
-                    case 'h':
-
-                        if (!(sourseText.contains("hv") || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
-                            return false;
-                        }
-
-                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("uhv")
-                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2))) {
-                            return true;
-                        }
-
-                        return CONTEXT.contains(sourseText, searchText.substring(0, j - 1));
-
-                    case 'e':
-
-                        if (!(sourseText.contains("ev") || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
-                            return false;
-                        }
-
-                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("uev")
-                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2))) {
-                            return true;
-                        }
-
-                        return CONTEXT.contains(sourseText, searchText.substring(0, j - 1));
-
-                    case 'i':
-
-                        if (!(sourseText.contains("iv") || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
-                            return false;
-                        }
-
-                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("uiv")
-                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2))) {
-                            return true;
-                        }
-
-                        return CONTEXT.contains(sourseText, searchText.substring(0, j - 1));
-
-                    case 'u':
-
-                        if (!(sourseText.contains("uv") || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
-                            return false;
-                        }
-
-                        if (searchText.charAt(j - 2) == 'l' && sourseText.contains("luv")
-                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2))) {
-                            return true;
-                        }
-
-                        return CONTEXT.contains(sourseText, searchText.substring(0, j - 1));
-
-                    case 'x':
-
-                        if (searchText.charAt(j - 2) != 'u') {
-                            break;
-                        }
-
-                        return sourseText.contains("uxv") && CONTEXT.contains(sourseText, searchText.substring(j + 1))
-                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2));
-
-                    default:
-                        break;
-                }
+        if (containWithVoltage("zpm", sourseText, searchText) || containWithVoltage("max", sourseText, searchText)) {
+            return true;
+        }
+        if (!(sourseText.contains('v') || searchText.contains('v'))) {
+            return false;
+        }
+        for (String name : voltageListWithLetterV) {
+            if (containWithVoltage(name, sourseText, searchText)) {
+                return true;
             }
         }
-
         return false;
-
     }
     // return CONTEXT.contains(sourseText, searchText);
 

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -62,7 +62,7 @@ public class NecharUtils {
         }
 
         // may be very slow, only try to find 1 voltage level
-        if (!EnableVoltageSpecialSearch) {
+        if (!(EnableVoltageSpecialSearch || enableSpecialSearch)) {
             return false;
         }
 

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -1,7 +1,6 @@
 package net.sst03.nechar;
 
 import static net.moecraft.nechar.NotEnoughCharacters.CONTEXT;
-
 import static net.vfyjxf.nechar.NechConfig.EnableIgnoreComma;
 import static net.vfyjxf.nechar.NechConfig.EnableVoltageSpecialSearch;
 
@@ -13,19 +12,19 @@ public class NecharUtils {
 
     private static String replaceExtraChars(String str) {
 
-        if (str.contains("\ud872")) {
-            str = str.replaceAll("\ud872\udf3b","\ue900") // 钅卢
-                .replaceAll("\ud872\udf4a","\ue901") // 钅杜
-                .replaceAll("\ud872\udf73","\ue902") // 钅喜
-                .replaceAll("\ud872\udf5b","\ue903") // 钅波
-                .replaceAll("\ud872\udf76","\ue904") // 钅黑
-                .replaceAll("\ud872\udf2d","\ue907"); // 钅仑
+		if (str.contains("\ud872")) {
+			str = str.replaceAll("\ud872\udf3b","\ue900") // 钅卢
+				.replaceAll("\ud872\udf4a","\ue901") // 钅杜
+				.replaceAll("\ud872\udf73","\ue902") // 钅喜
+				.replaceAll("\ud872\udf5b","\ue903") // 钅波
+				.replaceAll("\ud872\udf76","\ue904") // 钅黑
+				.replaceAll("\ud872\udf2d","\ue907"); // 钅仑
         }
 
         if (str.contains("\ud86d")) {
-            str = str.replaceAll("\ud86d\udffc","\ue906") // 钅达
-                .replaceAll("\ud86d\udce7","\ue90a") // 钅夫
-                .replaceAll("\ud86d\udff7","\ue90c"); // 钅仑
+			str = str.replaceAll("\ud86d\udffc","\ue906") // 钅达
+				.replaceAll("\ud86d\udce7","\ue90a") // 钅夫
+				.replaceAll("\ud86d\udff7","\ue90c"); // 钅仑
         }
 
         return str;
@@ -55,7 +54,7 @@ public class NecharUtils {
         if (searchText.contains("max")) {
             sourseText = sourseText.toLowerCase();
 
-            if (!sourseText.contains("max")) { //check if "max" can be found
+            if (!sourseText.contains("max")) { // check if "max" can be found
                 return false;
             }
 

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -9,11 +9,11 @@ public class NecharUtils {
     }
 
     private static String deleteExtraChars(String str) {
-        return str.replaceAll("\ud872","")
-            .replaceAll("\ud86d","");
+        return str.replaceAll("\ud872", "")
+            .replaceAll("\ud86d", "");
     }
 
-    public static boolean contain(String searchText,String sourseText) {
+    public static boolean contain(String searchText, String sourseText) {
 
         if (!(searchText.contains("\ud872") || searchText.contains("\ud86d"))) {
             searchText = deleteExtraChars(searchText);

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -12,19 +12,19 @@ public class NecharUtils {
 
     private static String replaceExtraChars(String str) {
 
-		if (str.contains("\ud872")) {
-			str = str.replaceAll("\ud872\udf3b","\ue900") // 钅卢
-				.replaceAll("\ud872\udf4a","\ue901") // 钅杜
-				.replaceAll("\ud872\udf73","\ue902") // 钅喜
-				.replaceAll("\ud872\udf5b","\ue903") // 钅波
-				.replaceAll("\ud872\udf76","\ue904") // 钅黑
-				.replaceAll("\ud872\udf2d","\ue907"); // 钅仑
+        if (str.contains("\ud872")) {
+            str = str.replaceAll("\ud872\udf3b","\ue900") // 钅卢
+                .replaceAll("\ud872\udf4a","\ue901") // 钅杜
+                .replaceAll("\ud872\udf73","\ue902") // 钅喜
+                .replaceAll("\ud872\udf5b","\ue903") // 钅波
+                .replaceAll("\ud872\udf76","\ue904") // 钅黑
+                .replaceAll("\ud872\udf2d","\ue907"); // 钅仑
         }
 
         if (str.contains("\ud86d")) {
-			str = str.replaceAll("\ud86d\udffc","\ue906") // 钅达
-				.replaceAll("\ud86d\udce7","\ue90a") // 钅夫
-				.replaceAll("\ud86d\udff7","\ue90c"); // 钅仑
+            str = str.replaceAll("\ud86d\udffc","\ue906") // 钅达
+                .replaceAll("\ud86d\udce7","\ue90a") // 钅夫
+                .replaceAll("\ud86d\udff7","\ue90c"); // 钅仑
         }
 
         return str;
@@ -69,7 +69,7 @@ public class NecharUtils {
         } else if (searchText.contains("zpm")) {
             sourseText = sourseText.toLowerCase();
 
-            if (!sourseText.contains("zpm")) { //check if "zpm" can be found
+            if (!sourseText.contains("zpm")) { // check if "zpm" can be found
                 return false;
             }
 
@@ -91,9 +91,9 @@ public class NecharUtils {
             int i = 1;// voltage name is like "??v", not "v?"
             final int l = searchText.length();
 
-            //try to find a voltage name
-            while (i < l){
-                int j = searchText.indexOf('v',i);
+            // try to find a voltage name
+            while (i < l) {
+                int j = searchText.indexOf('v', i);
 
                 if (j == -1) { // cannot find any voltage name
                     return false;

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -27,4 +27,5 @@ public class NecharUtils {
 
         return CONTEXT.contains(sourseText, searchText);
     }
+
 }

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -12,7 +12,7 @@ public class NecharUtils {
         return str.replaceAll("\ud872","").replaceAll("\ud86d","");
     }
 
-    public static String contain(String searchText,String sourseText) {
+    public static boolean contain(String searchText,String sourseText) {
 
         if (!(searchText.contains("\ud872") || searchText.contains("\ud86d"))) {
             searchText = deleteUnlegalChars(searchText);

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -2,30 +2,208 @@ package net.sst03.nechar;
 
 import static net.moecraft.nechar.NotEnoughCharacters.CONTEXT;
 
+import static net.vfyjxf.nechar.NechConfig.EnableIgnoreComma;
+import static net.vfyjxf.nechar.NechConfig.EnableVoltageSpecialSearch;
+
 public class NecharUtils {
 
     private static String deleteComma(String str) {
         return str.replaceAll("(?<=[0-9]),(?=[0-9])", "");
     }
 
-    private static String deleteExtraChars(String str) {
-        return str.replaceAll("\ud872", "")
-            .replaceAll("\ud86d", "");
+    private static String replaceExtraChars(String str) {
+
+        if (str.contains("\ud872")) {
+            str = str.replaceAll("\ud872\udf3b","\ue900") // 钅卢
+                .replaceAll("\ud872\udf4a","\ue901") // 钅杜
+                .replaceAll("\ud872\udf73","\ue902") // 钅喜
+                .replaceAll("\ud872\udf5b","\ue903") // 钅波
+                .replaceAll("\ud872\udf76","\ue904") // 钅黑
+                .replaceAll("\ud872\udf2d","\ue907"); // 钅仑
+        }
+
+        if (str.contains("\ud86d")) {
+            str = str.replaceAll("\ud86d\udffc","\ue906") // 钅达
+                .replaceAll("\ud86d\udce7","\ue90a") // 钅夫
+                .replaceAll("\ud86d\udff7","\ue90c"); // 钅仑
+        }
+
+        return str;
     }
 
     public static boolean contain(String sourseText, String searchText) {
 
-        if (!(searchText.contains("\ud872") || searchText.contains("\ud86d"))) {
-            searchText = deleteExtraChars(searchText);
-            sourseText = deleteExtraChars(sourseText);
-        }
+        searchText = replaceExtraChars(searchText);
+        sourseText = replaceExtraChars(sourseText);
 
-        if (!searchText.contains(",")) {
+        if (EnableIgnoreComma && !searchText.contains(",")) {
             searchText = deleteComma(searchText);
             sourseText = deleteComma(sourseText);
         }
 
-        return CONTEXT.contains(sourseText, searchText);
+        if (CONTEXT.contains(sourseText, searchText)) {
+            return true;
+        }
+
+        // may be very slow, only try to find 1 voltage level
+        if (!EnableVoltageSpecialSearch) {
+            return false;
+        }
+
+        searchText = searchText.toLowerCase();
+
+        if (searchText.contains("max")) {
+            sourseText = sourseText.toLowerCase();
+
+            if (!sourseText.contains("max")) { //check if "max" can be found
+                return false;
+            }
+
+            String[] sList = searchText.split("max"); // check if texts between "max" can be found
+
+            if (sList.length == 2 && !CONTEXT.contains(sourseText, sList[1])) {
+                return false;
+            }
+
+            return CONTEXT.contains(sourseText, sList[0]);
+
+        } else if (searchText.contains("zpm")) {
+            sourseText = sourseText.toLowerCase();
+
+            if (!sourseText.contains("zpm")) { //check if "zpm" can be found
+                return false;
+            }
+
+            String[] sList = searchText.split("zpm"); // check if texts between "zpm" can be found
+
+            if (sList.length == 2 && !CONTEXT.contains(sourseText, sList[1])) {
+                return false;
+            }
+
+            return CONTEXT.contains(sourseText, sList[0]);
+
+        } else if (searchText.contains("v")) {
+            sourseText = sourseText.toLowerCase();
+
+            if (!sourseText.contains("v")) {
+                return false;
+            }
+
+            int i = 1;// voltage name is like "??v", not "v?"
+            final int l = searchText.length;
+
+            //try to find a voltage name
+            while (i < l){
+                int j = searchText.indexOf('v',i);
+
+                if (j == -1) { // cannot find any voltage name
+                    return false;
+                }
+
+                i = j + 1;
+                switch(searchText.charAt(j - 1)) { // ulv/umv/uhv/uiv/uev are basicly same
+                    case 'l' :
+
+                        if (!(sourseText.contains("lv") 
+                            || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
+                            return false;
+                        }
+
+                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("ulv") 
+                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2))) {
+                            return true;
+                        }
+
+                        return CONTEXT.contains(sourseText, searchText.substring(0,j - 1));
+
+                    case 'm' :
+
+                        if (!(sourseText.contains("mv") 
+                            || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
+                            return false;
+                        }
+
+                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("umv") 
+                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2))) {
+                            return true;
+                        }
+
+                        return CONTEXT.contains(sourseText, searchText.substring(0,j - 1));
+
+                    case 'h' :
+
+                        if (!(sourseText.contains("hv") 
+                            || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
+                            return false;
+                        }
+
+                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("uhv") 
+                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2))) {
+                            return true;
+                        }
+
+                        return CONTEXT.contains(sourseText, searchText.substring(0,j - 1));
+
+                    case 'e' :
+
+                        if (!(sourseText.contains("ev") 
+                            || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
+                            return false;
+                        }
+
+                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("uev") 
+                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2))) {
+                            return true;
+                        }
+
+                        return CONTEXT.contains(sourseText, searchText.substring(0,j - 1));
+
+                    case 'i' :
+
+                        if (!(sourseText.contains("iv") 
+                            || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
+                            return false;
+                        }
+
+                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("uiv") 
+                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2))) {
+                            return true;
+                        }
+
+                        return CONTEXT.contains(sourseText, searchText.substring(0,j - 1));
+
+                    case 'u' :
+
+                        if (!(sourseText.contains("uv") 
+                            || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
+                            return false;
+                        }
+
+                        if (searchText.charAt(j - 2) == 'l' && sourseText.contains("luv") 
+                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2))) {
+                            return true;
+                        }
+
+                        return CONTEXT.contains(sourseText, searchText.substring(0,j - 1));
+                        
+                    case 'x' :
+
+                        if (!searchText.charAt(j - 2) == 'u') {
+                            break;
+                        }
+
+                        return sourseText.contains("uxv") && CONTEXT.contains(sourseText, searchText.substring(j + 1))
+                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2));
+
+                    default :
+                        break;
+                }
+            }
+        }
+
+        return false;
+ 
     }
+        //return CONTEXT.contains(sourseText, searchText);
 
 }

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -13,7 +13,7 @@ public class NecharUtils {
             .replaceAll("\ud86d", "");
     }
 
-    public static boolean contain(String searchText, String sourseText) {
+    public static boolean contain(String sourseText, String searchText) {
 
         if (!(searchText.contains("\ud872") || searchText.contains("\ud86d"))) {
             searchText = deleteExtraChars(searchText);

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -2,7 +2,6 @@ package net.sst03.nechar;
 
 import static net.moecraft.nechar.NotEnoughCharacters.CONTEXT;
 import static net.vfyjxf.nechar.NechConfig.EnableIgnoreComma;
-import static net.vfyjxf.nechar.NechConfig.EnableVoltageSpecialSearch;
 
 public class NecharUtils {
 
@@ -62,7 +61,7 @@ public class NecharUtils {
         }
 
         // may be very slow, only try to find 1 voltage level
-        if (!(EnableVoltageSpecialSearch || enableSpecialSearch)) {
+        if (!enableSpecialSearch) {
             return false;
         }
 

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -90,7 +90,7 @@ public class NecharUtils {
             }
 
             int i = 1;// voltage name is like "??v", not "v?"
-            final int l = searchText.length;
+            final int l = searchText.length();
 
             //try to find a voltage name
             while (i < l){
@@ -188,7 +188,7 @@ public class NecharUtils {
                         
                     case 'x' :
 
-                        if (!searchText.charAt(j - 2) == 'u') {
+                        if (searchText.charAt(j - 2) != 'u') {
                             break;
                         }
 

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -12,7 +12,7 @@ public class NecharUtils {
         return str.replaceAll("\ud872","").replaceAll("\ud86d","");
     }
 
-    public static contain(String searchText,String sourseText) {
+    public static String contain(String searchText,String sourseText) {
 
         if (!(searchText.contains("\ud872") || !searchText.contains("\ud86d"))) {
             searchText = deleteUnlegalChars(searchText);

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -8,15 +8,15 @@ public class NecharUtils {
         return str.replaceAll("(?<=[0-9]),(?=[0-9])", "");
     }
 
-    private static String deleteUnlegalChars(String str) {
+    private static String deleteExtraChars(String str) {
         return str.replaceAll("\ud872","").replaceAll("\ud86d","");
     }
 
     public static boolean contain(String searchText,String sourseText) {
 
         if (!(searchText.contains("\ud872") || searchText.contains("\ud86d"))) {
-            searchText = deleteUnlegalChars(searchText);
-            sourseText = deleteUnlegalChars(sourseText);
+            searchText = deleteExtraChars(searchText);
+            sourseText = deleteExtraChars(sourseText);
         }
 
         if (!searchText.contains(",")) {

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -9,7 +9,8 @@ public class NecharUtils {
     }
 
     private static String deleteExtraChars(String str) {
-        return str.replaceAll("\ud872","").replaceAll("\ud86d","");
+        return str.replaceAll("\ud872","")
+            .replaceAll("\ud86d","");
     }
 
     public static boolean contain(String searchText,String sourseText) {

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -4,17 +4,17 @@ import static net.moecraft.nechar.NotEnoughCharacters.CONTEXT;
 
 public class NecharUtils {
 
-    private String deleteComma(String str) {
+    private static String deleteComma(String str) {
         return str.replaceAll("(?<=[0-9]),(?=[0-9])", "");
     }
 
-    private String deleteUnlegalChars(String str) {
+    private static String deleteUnlegalChars(String str) {
         return str.replaceAll("\ud872","").replaceAll("\ud86d","");
     }
 
     public static String contain(String searchText,String sourseText) {
 
-        if (!(searchText.contains("\ud872") || !searchText.contains("\ud86d"))) {
+        if (!(searchText.contains("\ud872") || searchText.contains("\ud86d"))) {
             searchText = deleteUnlegalChars(searchText);
             sourseText = deleteUnlegalChars(sourseText);
         }

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -13,18 +13,18 @@ public class NecharUtils {
     private static String replaceExtraChars(String str) {
 
         if (str.contains("\ud872")) {
-            str = str.replaceAll("\ud872\udf3b","\ue900") // 钅卢
-                .replaceAll("\ud872\udf4a","\ue901") // 钅杜
-                .replaceAll("\ud872\udf73","\ue902") // 钅喜
-                .replaceAll("\ud872\udf5b","\ue903") // 钅波
-                .replaceAll("\ud872\udf76","\ue904") // 钅黑
-                .replaceAll("\ud872\udf2d","\ue907"); // 钅仑
+            str = str.replaceAll("\ud872\udf3b", "\ue900") // 钅卢
+                .replaceAll("\ud872\udf4a", "\ue901") // 钅杜
+                .replaceAll("\ud872\udf73", "\ue902") // 钅喜
+                .replaceAll("\ud872\udf5b", "\ue903") // 钅波
+                .replaceAll("\ud872\udf76", "\ue904") // 钅黑
+                .replaceAll("\ud872\udf2d", "\ue907"); // 钅仑
         }
 
         if (str.contains("\ud86d")) {
-            str = str.replaceAll("\ud86d\udffc","\ue906") // 钅达
-                .replaceAll("\ud86d\udce7","\ue90a") // 钅夫
-                .replaceAll("\ud86d\udff7","\ue90c"); // 钅仑
+            str = str.replaceAll("\ud86d\udffc", "\ue906") // 钅达
+                .replaceAll("\ud86d\udce7", "\ue90a") // 钅夫
+                .replaceAll("\ud86d\udff7", "\ue90c"); // 钅仑
         }
 
         return str;
@@ -100,109 +100,103 @@ public class NecharUtils {
                 }
 
                 i = j + 1;
-                switch(searchText.charAt(j - 1)) { // ulv/umv/uhv/uiv/uev are basicly same
-                    case 'l' :
+                switch (searchText.charAt(j - 1)) { // ulv/umv/uhv/uiv/uev are basicly same
+                    case 'l':
 
-                        if (!(sourseText.contains("lv") 
-                            || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
+                        if (!(sourseText.contains("lv") || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
                             return false;
                         }
 
-                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("ulv") 
-                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2))) {
+                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("ulv")
+                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2))) {
                             return true;
                         }
 
-                        return CONTEXT.contains(sourseText, searchText.substring(0,j - 1));
+                        return CONTEXT.contains(sourseText, searchText.substring(0, j - 1));
 
-                    case 'm' :
+                    case 'm':
 
-                        if (!(sourseText.contains("mv") 
-                            || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
+                        if (!(sourseText.contains("mv") || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
                             return false;
                         }
 
-                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("umv") 
-                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2))) {
+                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("umv")
+                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2))) {
                             return true;
                         }
 
-                        return CONTEXT.contains(sourseText, searchText.substring(0,j - 1));
+                        return CONTEXT.contains(sourseText, searchText.substring(0, j - 1));
 
-                    case 'h' :
+                    case 'h':
 
-                        if (!(sourseText.contains("hv") 
-                            || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
+                        if (!(sourseText.contains("hv") || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
                             return false;
                         }
 
-                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("uhv") 
-                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2))) {
+                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("uhv")
+                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2))) {
                             return true;
                         }
 
-                        return CONTEXT.contains(sourseText, searchText.substring(0,j - 1));
+                        return CONTEXT.contains(sourseText, searchText.substring(0, j - 1));
 
-                    case 'e' :
+                    case 'e':
 
-                        if (!(sourseText.contains("ev") 
-                            || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
+                        if (!(sourseText.contains("ev") || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
                             return false;
                         }
 
-                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("uev") 
-                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2))) {
+                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("uev")
+                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2))) {
                             return true;
                         }
 
-                        return CONTEXT.contains(sourseText, searchText.substring(0,j - 1));
+                        return CONTEXT.contains(sourseText, searchText.substring(0, j - 1));
 
-                    case 'i' :
+                    case 'i':
 
-                        if (!(sourseText.contains("iv") 
-                            || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
+                        if (!(sourseText.contains("iv") || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
                             return false;
                         }
 
-                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("uiv") 
-                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2))) {
+                        if (searchText.charAt(j - 2) == 'u' && sourseText.contains("uiv")
+                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2))) {
                             return true;
                         }
 
-                        return CONTEXT.contains(sourseText, searchText.substring(0,j - 1));
+                        return CONTEXT.contains(sourseText, searchText.substring(0, j - 1));
 
-                    case 'u' :
+                    case 'u':
 
-                        if (!(sourseText.contains("uv") 
-                            || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
+                        if (!(sourseText.contains("uv") || CONTEXT.contains(sourseText, searchText.substring(j + 1)))) {
                             return false;
                         }
 
-                        if (searchText.charAt(j - 2) == 'l' && sourseText.contains("luv") 
-                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2))) {
+                        if (searchText.charAt(j - 2) == 'l' && sourseText.contains("luv")
+                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2))) {
                             return true;
                         }
 
-                        return CONTEXT.contains(sourseText, searchText.substring(0,j - 1));
-                        
-                    case 'x' :
+                        return CONTEXT.contains(sourseText, searchText.substring(0, j - 1));
+
+                    case 'x':
 
                         if (searchText.charAt(j - 2) != 'u') {
                             break;
                         }
 
                         return sourseText.contains("uxv") && CONTEXT.contains(sourseText, searchText.substring(j + 1))
-                            && CONTEXT.contains(sourseText, searchText.substring(0,j - 2));
+                            && CONTEXT.contains(sourseText, searchText.substring(0, j - 2));
 
-                    default :
+                    default:
                         break;
                 }
             }
         }
 
         return false;
- 
+
     }
-        //return CONTEXT.contains(sourseText, searchText);
+    // return CONTEXT.contains(sourseText, searchText);
 
 }

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -72,7 +72,7 @@ public class NecharUtils {
         if (containWithVoltage("zpm", sourseText, searchText) || containWithVoltage("max", sourseText, searchText)) {
             return true;
         }
-        if (!(sourseText.contains('v') || searchText.contains('v'))) {
+        if (!(sourseText.contains("v") || searchText.contains("v"))) {
             return false;
         }
         for (String name : voltageListWithLetterV) {

--- a/src/main/java/net/sst03/nechar/NecharUtils.java
+++ b/src/main/java/net/sst03/nechar/NecharUtils.java
@@ -1,0 +1,29 @@
+package net.sst03.nechar;
+
+import static net.moecraft.nechar.NotEnoughCharacters.CONTEXT;
+
+public class NecharUtils {
+
+    private String deleteComma(String str) {
+        return str.replaceAll("(?<=[0-9]),(?=[0-9])", "");
+    }
+
+    private String deleteUnlegalChars(String str) {
+        return str.replaceAll("\ud872","").replaceAll("\ud86d","");
+    }
+
+    public static contain(String searchText,String sourseText) {
+
+        if (!(searchText.contains("\ud872") || !searchText.contains("\ud86d"))) {
+            searchText = deleteUnlegalChars(searchText);
+            sourseText = deleteUnlegalChars(sourseText);
+        }
+
+        if (!searchText.contains(",")) {
+            searchText = deleteComma(searchText);
+            sourseText = deleteComma(sourseText);
+        }
+
+        return CONTEXT.contains(sourseText, searchText);
+    }
+}

--- a/src/main/java/net/vfyjxf/nechar/NechConfig.java
+++ b/src/main/java/net/vfyjxf/nechar/NechConfig.java
@@ -18,7 +18,8 @@ public class NechConfig {
     public static boolean EnableFEng2En = false;
     public static boolean EnableFU2V = false;
     public static boolean EnableIgnoreComma = false;
-    public static boolean EnableVoltageSpecialSearch = false;
+    public static boolean EnableVoltageSpecialSearchName = false;
+    public static boolean EnableVoltageSpecialSearchTooltips = false;
     public static Spell KeyboardType = Spell.QUANPIN;
     public static String[] neiAllowedLanguages = new String[0];
     public static String[] transformerRegExpAdditionalList = new String[0];
@@ -150,11 +151,22 @@ public class NechConfig {
             .get("nei", "allowedLanguages", new String[] { "zh_CN", "zh_TW" }, "List of languages PinIn is used for")
             .getStringList();
         EnableIgnoreComma = config
-            .get("nei", "EnableIgnoreComma", false, "Set to true to enable ignore comma between numbers")
+            .get("search", "EnableIgnoreComma", false, "Set to true to enable ignore comma between numbers")
             .getBoolean();
-        EnableVoltageSpecialSearch = config
-            .get("nei", "EnableVoltageSpecialSearch", false, "!Slow! Set to true to search Voltage names separately")
-            .getBoolean();;
+        EnableVoltageSpecialSearchName = config
+            .get(
+                "search",
+                "EnableVoltageSpecialSearchName",
+                false,
+                "!Slow! Set to true to search Voltage names separately for item names")
+            .getBoolean();
+        EnableVoltageSpecialSearchTooltips = config
+            .get(
+                "search",
+                "EnableVoltageSpecialSearchTooltips",
+                false,
+                "!Slow! Set to true to search Voltage names separately for tooltips")
+            .getBoolean();
 
         if (config.hasChanged()) config.save();
     }

--- a/src/main/java/net/vfyjxf/nechar/NechConfig.java
+++ b/src/main/java/net/vfyjxf/nechar/NechConfig.java
@@ -149,9 +149,11 @@ public class NechConfig {
         neiAllowedLanguages = config
             .get("nei", "allowedLanguages", new String[] { "zh_CN", "zh_TW" }, "List of languages PinIn is used for")
             .getStringList();
-        EnableIgnoreComma = config.get("nei", "EnableIgnoreComma", false, "Set to true to enable ignore comma between numbers")
+        EnableIgnoreComma = config
+            .get("nei", "EnableIgnoreComma", false, "Set to true to enable ignore comma between numbers")
             .getBoolean();
-        EnableVoltageSpecialSearch = config.get("nei", "EnableVoltageSpecialSearch", false, "!Slow! Set to true to search Voltage names separately")
+        EnableVoltageSpecialSearch = config
+            .get("nei", "EnableVoltageSpecialSearch", false, "!Slow! Set to true to search Voltage names separately")
             .getBoolean();;
 
         if (config.hasChanged()) config.save();

--- a/src/main/java/net/vfyjxf/nechar/NechConfig.java
+++ b/src/main/java/net/vfyjxf/nechar/NechConfig.java
@@ -17,6 +17,8 @@ public class NechConfig {
     public static boolean EnableFIng2In = false;
     public static boolean EnableFEng2En = false;
     public static boolean EnableFU2V = false;
+    public static boolean EnableIgnoreComma = false;
+    public static boolean EnableVoltageSpecialSearch = false;
     public static Spell KeyboardType = Spell.QUANPIN;
     public static String[] neiAllowedLanguages = new String[0];
     public static String[] transformerRegExpAdditionalList = new String[0];
@@ -147,6 +149,10 @@ public class NechConfig {
         neiAllowedLanguages = config
             .get("nei", "allowedLanguages", new String[] { "zh_CN", "zh_TW" }, "List of languages PinIn is used for")
             .getStringList();
+        EnableIgnoreComma = config.get("nei", "EnableIgnoreComma", false, "Set to true to enable ignore comma between numbers")
+            .getBoolean();
+        EnableVoltageSpecialSearch = config.get("nei", "EnableVoltageSpecialSearch", false, "!Slow! Set to true to search Voltage names separately")
+            .getBoolean();;
 
         if (config.hasChanged()) config.save();
     }

--- a/src/main/java/net/vfyjxf/nechar/NechConfig.java
+++ b/src/main/java/net/vfyjxf/nechar/NechConfig.java
@@ -17,9 +17,9 @@ public class NechConfig {
     public static boolean EnableFIng2In = false;
     public static boolean EnableFEng2En = false;
     public static boolean EnableFU2V = false;
-    public static boolean EnableIgnoreComma = false;
-    public static boolean EnableVoltageSpecialSearchName = false;
-    public static boolean EnableVoltageSpecialSearchTooltips = false;
+    public static boolean enableIgnoreComma = false;
+    public static boolean enableVoltageSpecialSearchName = false;
+    public static boolean enableVoltageSpecialSearchTooltips = false;
     public static Spell KeyboardType = Spell.QUANPIN;
     public static String[] neiAllowedLanguages = new String[0];
     public static String[] transformerRegExpAdditionalList = new String[0];
@@ -150,20 +150,20 @@ public class NechConfig {
         neiAllowedLanguages = config
             .get("nei", "allowedLanguages", new String[] { "zh_CN", "zh_TW" }, "List of languages PinIn is used for")
             .getStringList();
-        EnableIgnoreComma = config
-            .get("search", "EnableIgnoreComma", false, "Set to true to enable ignore comma between numbers")
+        enableIgnoreComma = config
+            .get("search", "enableIgnoreComma", false, "Set to true to enable ignore comma between numbers")
             .getBoolean();
-        EnableVoltageSpecialSearchName = config
+        enableVoltageSpecialSearchName = config
             .get(
                 "search",
-                "EnableVoltageSpecialSearchName",
+                "enableVoltageSpecialSearchName",
                 false,
                 "!Slow! Set to true to search Voltage names separately for item names")
             .getBoolean();
-        EnableVoltageSpecialSearchTooltips = config
+        enableVoltageSpecialSearchTooltips = config
             .get(
                 "search",
-                "EnableVoltageSpecialSearchTooltips",
+                "enableVoltageSpecialSearchTooltips",
                 false,
                 "!Slow! Set to true to search Voltage names separately for tooltips")
             .getBoolean();


### PR DESCRIPTION
My English is bad.
some features are disabled in default config and can be opened in NotEnoughCharacters.cfg.

1. if users search "65,536" (or other texts with ","), "," will not be ignored.
else, for example if user search "655", items like "uiv 65,536 hatch" will be searched.
this feature is set to disable in config (B:EnableIgnoreComma=true)

2. now people can search elements like 𫟷(Lv) by using pinyin.

3. when people search something with voltage names (like “IV能源仓”/IV Energy Hatch), they can just search "ivnyc", for this example nech will try to match items with "iv" and "nyc", just like searching "iv nyc".
this feature is set to disable in config (B:EnableVoltageSpecialSearchName=true, B:EnableVoltageSpecialSearchTooltips=true)